### PR TITLE
safer default configuration value

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,16 @@ const (
 	// resync PersistentVolumeClaims.
 	DefaultResyncInterval = 30 * time.Second
 
+	// DefaultDeleteAfter is the default time after which
+	// PersistentVolumeClaims are deleted where their managing StatefulSet was
+	// deleted.
+	DefaultDeleteAfter = 24 * time.Hour
+
+	// DefaultLabelSelector is the default label selector that is used to
+	// identify StatefulSets whose PersistentVolumeClaims should be managed by
+	// kube-volume-cleaner.
+	DefaultLabelSelector = "kube-volume-cleaner.io/on-delete=cleanup-pvcs"
+
 	// DefaultControllerID is the default ID of the controller used to annotate
 	// PersistentVolumeClaims with in order to allow multiple controllers to
 	// coexist without interfering.
@@ -32,6 +42,8 @@ type Options struct {
 func NewDefaultOptions() *Options {
 	return &Options{
 		ControllerID:   DefaultControllerID,
+		LabelSelector:  DefaultLabelSelector,
+		DeleteAfter:    DefaultDeleteAfter,
 		ResyncInterval: DefaultResyncInterval,
 	}
 }


### PR DESCRIPTION
This changes the default deletion behaviour from immediate deletion to
scheduled deletion after 24h. Users should not be surprised with
accidental data loss if they run the controller for the first time, but
rather be able to cancel unwanted deletion requests before they are
executed.

This also sets the statefulset label selector to a sane default so that
users have to explicitly set it to an empty string if they really want
the controller to manage all statefulsets that are around.